### PR TITLE
Remove postgresql support

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,5 +14,4 @@ tox
 clint
 csvkit
 subsample
-django-postgres-copy
 datpy

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ Secretary of State\'s CAL-ACCESS database',
         'csvkit',
         'requests',
         'clint',
-        'hurry.filesize',
-        'django-postgres-copy',
+        'hurry.filesize'
     ),
     classifiers=(
         'Programming Language :: Python',


### PR DESCRIPTION
Installing the django-postgres-copy package requires the postgres client
libraries. Since we are standardizing on MySQL, we should only require
the installation of _those_ client libraries.
